### PR TITLE
Potentially fix init branch.

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -eo pipefail
-
-# export SOAPUI_PATH="${ASDF_INSTALL_PATH}/bin/SoapUI-$ASDF_INSTALL_VERSION/bin"
-echo "SOAPUI_PATH=${ASDF_INSTALL_PATH}/bin/SoapUI-$ASDF_INSTALL_VERSION/bin" >> $GITHUB_ENV

--- a/bin/exec-path
+++ b/bin/exec-path
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-# custom_path="$ASDF_INSTALL_PATH/bin/soapui/$ASDF_INSTALL_VERSION/SoapUI-$ASDF_INSTALL_VERSION/bin"
-# echo "CUSTOM PATH ==> $custom_path"
-# echo "SoapUI-$ASDF_INSTALL_VERSION/bin"
-# plugin/bin/exec-path "$custom_path"
-# ~/.asdf/installs/soapui/bin/exec-path "~/.asdf/installs/soapui/5.7.0/SoapUI-5.7.0/" "test -f" "bin/testrunner.sh"

--- a/bin/list-bin-paths
+++ b/bin/list-bin-paths
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-IFS=$'\n\t'
-
-# pwd
-# ls -a
-"SoapUI-$ASDF_INSTALL_VERSION/bin"


### PR DESCRIPTION
Running the bin/list-all and bin/download and bin/install commands with the following arguments "works" on my machine:

- `bin/list-all`
- `ASDF_DOWNLOAD_PATH=t/download ASDF_INSTALL_TYPE=version ASDF_INSTALL_VERSION=5.7.0 ASDF_INSTALL_PATH=t/install ./bin/install`
- `ASDF_INSTALL_VERSION=5.7.0 ASDF_DOWNLOAD_PATH=t/download ./bin/download`

I have not tested the resulting installed version of SoapUI that would now live in `t/install`. I have also not tested the GitHub actions yet.

This PR is just a theoretical fix for the three base commands of the plugin itself.